### PR TITLE
Fix comment case in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,7 @@
 *.out
 *.app
 
-# debug information files
+# Debug information files
 *.dwo
 # Log files
 *.log


### PR DESCRIPTION
## Summary
- capitalize the comment about debug info in `.gitignore`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b646ec59c8331b13e9f17b56ffe34